### PR TITLE
Dumping of prefab names into C# file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,4 @@ You can then just drag and drop the sprites/wiki pages in your local repo of the
 If you want to change the content of the sprites pages please create a PR for this mod and don't edit the pages manually.
 All the text can be found in the ``SpriteDumperObj.cs`` class.
 
+Also generates a class containing all buildings/roads/vehicles.

--- a/SpriteDumper/PrefabDumperObj.cs
+++ b/SpriteDumper/PrefabDumperObj.cs
@@ -5,24 +5,25 @@ using UnityEngine;
 
 namespace SpriteDumper {
     public class PrefabDumperObj : MonoBehaviour {
-
-        private string prefabPath = "PrefabDumper\\PrefabDumper";
-        private string wikiTemplate = "" +
-                ".. WARNING FOR CONTRIBUTORS: Don't modify this file! It's generated with a mod (see below) and all changes made will be lost with the next update.\r\n\r\n" +
-                "==========\r\n" +
-                "Prefab {TYPE}\r\n" +
-                "==========\r\n" +
-                "Here you can find a list of prefabricated {TYPE}.\r\n" +
-                "You can use these to get the index of the {TYPE} you want to create.\r\n" +
-                "To get the {TYPE}, do: {TYPE} my{TYPE} = PrefabCollection<{TYPE}>.GetPrefab(index)\r\n" +
-                "\r\n\r\n {PREFABS} \r\n" +
-                "About this page\r\n" +
-                "---------------\r\n" +
-                "This wiki page was created in game with the `SpriteDumper mod <https://github.com/worstboy32/SpriteDumper>`__ .\r\n" +
-                "To modify the text in this document please create a PR on the mod on github.\r\n" +
-                "If there are sprites missing you can run the mod and create a PR on the docs repo with the new generated file.\r\n" +
-                "\r\n" +
-                "Kudos to `Permutation <http://www.skylinesmodding.com/users/permutation/>`__ for sharing the method for dumping sprites.\r\n";
+        private string template =
+                "namespace SkylinesGIS\n" +
+                "{\n" +
+                "    class PrefabNames\n" +
+                "    {\n" +
+                "        class Buildings\n" +
+                "        {\n" +
+                "{BUILDINGS}\n" +
+                "        }\n\n" +
+                "        class Vehicles\n" +
+                "        {\n" +
+                "{VEHICLES}\n" +
+                "        }\n" + 
+                "        class Roads\n" +
+                "        {\n" + 
+                "{ROADS}\n" +
+                "        }\n" +
+                "    }\n"
+                + "}";
 
         void OnEnable() {
             Utils.Log("PrefabDumperObj created!");
@@ -41,41 +42,33 @@ namespace SpriteDumper {
             int count = PrefabCollection<VehicleInfo>.LoadedCount();
             for (uint x = 0; x < count; x += 1)
             {
-                prefabStr += "**" + "Name:" + PrefabCollection<VehicleInfo>.GetPrefab(x).name + ", Index: " + x + "**\r\n\r\n";
+                prefabStr += "            public static string " + PrefabCollection<VehicleInfo>.GetPrefab(x).name.Replace(" ", "").Replace("-", "") + " = \"" + PrefabCollection<VehicleInfo>.GetPrefab(x).name + "\";\n";
 
             }
-            string wikiPage = wikiTemplate;
-            wikiPage = wikiPage.Replace("{TYPE}", "VehicleInfo");
-            System.IO.StreamWriter file = new System.IO.StreamWriter("PrefabDumper\\" + "VehiclePrefabs.rst");
-            file.WriteLine(wikiPage.Replace("{PREFABS}", prefabStr));
-            file.Close();
+            
+            System.IO.StreamWriter file = new System.IO.StreamWriter("PrefabDumper\\" + "PrefabNames.cs");
+            template = template.Replace("{VEHICLES}", prefabStr);
             Utils.Log("Dumped " + count);
             
             prefabStr = "";
             count = PrefabCollection<BuildingInfo>.LoadedCount();
             for (uint x = 0; x < count; x += 1)
             {
-                prefabStr += "**" + "Name:" + PrefabCollection<BuildingInfo>.GetPrefab(x).name + ", Index: " + x + "**\r\n\r\n";
+                prefabStr += "            public static string " + PrefabCollection<BuildingInfo>.GetPrefab(x).name.Replace(" ", "").Replace("-", "") + " = \"" + PrefabCollection<BuildingInfo>.GetPrefab(x).name + "\";\n";
 
             }
-            wikiPage = wikiTemplate;
-            wikiPage = wikiPage.Replace("{TYPE}", "BuildingInfo");
-            file = new System.IO.StreamWriter("PrefabDumper\\" + "BuildingPrefabs.rst");
-            file.WriteLine(wikiPage.Replace("{PREFABS}", prefabStr));
-            file.Close();
+            template = template.Replace("{BUILDINGS}", prefabStr);
             Utils.Log("Dumped " + count);
             
             prefabStr = "";
             count = PrefabCollection<NetInfo>.LoadedCount();
             for (uint x = 0; x < count; x += 1)
             {
-                prefabStr += "**" + "Name:" + PrefabCollection<NetInfo>.GetPrefab(x).name + ", Index: " + x + "**\r\n\r\n";
+                prefabStr += "            public static string " + PrefabCollection<NetInfo>.GetPrefab(x).name.Replace(" ", "").Replace("-", "") + " = \"" + PrefabCollection<NetInfo>.GetPrefab(x).name + "\";\n";
 
             }
-            wikiPage = wikiTemplate;
-            wikiPage = wikiPage.Replace("{TYPE}", "NetInfo");
-            file = new System.IO.StreamWriter("PrefabDumper\\" + "NetPrefabs.rst");
-            file.WriteLine(wikiPage.Replace("{PREFABS}", prefabStr));
+            template = template.Replace("{ROADS}", prefabStr);
+            file.WriteLine(template);
             file.Close();
 
             Utils.Log("Dumped " + count);

--- a/SpriteDumper/PrefabDumperObj.cs
+++ b/SpriteDumper/PrefabDumperObj.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.IO;
+using ColossalFramework.UI;
+using UnityEngine;
+
+namespace SpriteDumper {
+    public class PrefabDumperObj : MonoBehaviour {
+
+        private string prefabPath = "PrefabDumper\\PrefabDumper";
+        private string wikiTemplate = "" +
+                ".. WARNING FOR CONTRIBUTORS: Don't modify this file! It's generated with a mod (see below) and all changes made will be lost with the next update.\r\n\r\n" +
+                "==========\r\n" +
+                "Prefab {TYPE}\r\n" +
+                "==========\r\n" +
+                "Here you can find a list of prefabricated roads/buildings/vehicles.\r\n" + 
+                "You can use these to get the VehicleInfo/BuildingInfo/NetInfo you want to create\r\n" +
+                "\r\n\r\n {PREFABS} \r\n" +
+                "About this page\r\n" +
+                "---------------\r\n" +
+                "This wiki page was created in game with the `SpriteDumper mod <https://github.com/worstboy32/SpriteDumper>`__ .\r\n" +
+                "To modify the text in this document please create a PR on the mod on github.\r\n" +
+                "If there are sprites missing you can run the mod and create a PR on the docs repo with the new generated file.\r\n" +
+                "\r\n" +
+                "Kudos to `Permutation <http://www.skylinesmodding.com/users/permutation/>`__ for sharing the method for dumping sprites.\r\n";
+
+        void OnEnable() {
+            Utils.Log("PrefabDumperObj created!");
+        }
+
+        void Update() {
+            if (Input.GetKey(KeyCode.LeftControl) && Input.GetKey(KeyCode.LeftShift) && Input.GetKeyDown(KeyCode.D)) {
+                Dump();
+            }
+        }
+
+        private void Dump() {
+            Utils.Log("Creating wiki page...");
+            if (Utils.CreateDir(prefabPath)) {
+                Utils.Log("Directory for prefab created at: '" + prefabPath + "'");
+            }
+
+            string prefabStr = "";
+            int count = PrefabCollection<VehicleInfo>.LoadedCount();
+            for (uint x = 0; x < count; x += 1)
+            {
+                prefabStr += "**" + "Name:" + PrefabCollection<VehicleInfo>.GetPrefab(x).name + ", Index: " + x + "**\r\n\r\n";
+
+            }
+            string wikiPage = wikiTemplate;
+            wikiPage = wikiPage.Replace("{TYPE}", "VehicleInfo");
+            System.IO.StreamWriter file = new System.IO.StreamWriter("PrefabDumper\\" + "VehiclePrefabs.rst");
+            file.WriteLine(wikiPage.Replace("{PREFABS}", prefabStr));
+            file.Close();
+            
+            prefabStr = "";
+            count = PrefabCollection<BuildingInfo>.LoadedCount();
+            for (uint x = 0; x < count; x += 1)
+            {
+                prefabStr += "**" + "Name:" + PrefabCollection<BuildingInfo>.GetPrefab(x).name + ", Index: " + x + "**\r\n\r\n";
+
+            }
+            wikiPage = wikiTemplate;
+            wikiPage = wikiPage.Replace("{TYPE}", "BuildingInfo");
+            System.IO.StreamWriter file = new System.IO.StreamWriter("PrefabDumper\\" + "BuildingPrefabs.rst");
+            file.WriteLine(wikiPage.Replace("{PREFABS}", prefabStr));
+            file.Close();
+            
+            prefabStr = "";
+            count = PrefabCollection<NetinfoInfo>.LoadedCount();
+            for (uint x = 0; x < count; x += 1)
+            {
+                prefabStr += "**" + "Name:" + PrefabCollection<NetinfoInfo>.GetPrefab(x).name + ", Index: " + x + "**\r\n\r\n";
+
+            }
+            wikiPage = wikiTemplate;
+            wikiPage = wikiPage.Replace("{TYPE}", "NetInfo (Roads)");
+            System.IO.StreamWriter file = new System.IO.StreamWriter("PrefabDumper\\" + "NetPrefabs.rst");
+            file.WriteLine(wikiPage.Replace("{PREFABS}", prefabStr));
+            file.Close();
+            
+            Utils.Log("Dumped " + count + " sprites to '" + spritePath + "'");
+        }
+
+    }
+}

--- a/SpriteDumper/PrefabDumperObj.cs
+++ b/SpriteDumper/PrefabDumperObj.cs
@@ -12,8 +12,9 @@ namespace SpriteDumper {
                 "==========\r\n" +
                 "Prefab {TYPE}\r\n" +
                 "==========\r\n" +
-                "Here you can find a list of prefabricated roads/buildings/vehicles.\r\n" + 
-                "You can use these to get the VehicleInfo/BuildingInfo/NetInfo you want to create\r\n" +
+                "Here you can find a list of prefabricated {TYPE}.\r\n" +
+                "You can use these to get the index of the {TYPE} you want to create.\r\n" +
+                "To get the {TYPE}, do: {TYPE} my{TYPE} = PrefabCollection<{TYPE}>.GetPrefab(index)\r\n" +
                 "\r\n\r\n {PREFABS} \r\n" +
                 "About this page\r\n" +
                 "---------------\r\n" +
@@ -34,10 +35,7 @@ namespace SpriteDumper {
         }
 
         private void Dump() {
-            Utils.Log("Creating wiki page...");
-            if (Utils.CreateDir(prefabPath)) {
-                Utils.Log("Directory for prefab created at: '" + prefabPath + "'");
-            }
+            Utils.Log("Creating wiki pages...");
 
             string prefabStr = "";
             int count = PrefabCollection<VehicleInfo>.LoadedCount();
@@ -51,6 +49,7 @@ namespace SpriteDumper {
             System.IO.StreamWriter file = new System.IO.StreamWriter("PrefabDumper\\" + "VehiclePrefabs.rst");
             file.WriteLine(wikiPage.Replace("{PREFABS}", prefabStr));
             file.Close();
+            Utils.Log("Dumped " + count);
             
             prefabStr = "";
             count = PrefabCollection<BuildingInfo>.LoadedCount();
@@ -61,24 +60,25 @@ namespace SpriteDumper {
             }
             wikiPage = wikiTemplate;
             wikiPage = wikiPage.Replace("{TYPE}", "BuildingInfo");
-            System.IO.StreamWriter file = new System.IO.StreamWriter("PrefabDumper\\" + "BuildingPrefabs.rst");
+            file = new System.IO.StreamWriter("PrefabDumper\\" + "BuildingPrefabs.rst");
             file.WriteLine(wikiPage.Replace("{PREFABS}", prefabStr));
             file.Close();
+            Utils.Log("Dumped " + count);
             
             prefabStr = "";
-            count = PrefabCollection<NetinfoInfo>.LoadedCount();
+            count = PrefabCollection<NetInfo>.LoadedCount();
             for (uint x = 0; x < count; x += 1)
             {
-                prefabStr += "**" + "Name:" + PrefabCollection<NetinfoInfo>.GetPrefab(x).name + ", Index: " + x + "**\r\n\r\n";
+                prefabStr += "**" + "Name:" + PrefabCollection<NetInfo>.GetPrefab(x).name + ", Index: " + x + "**\r\n\r\n";
 
             }
             wikiPage = wikiTemplate;
-            wikiPage = wikiPage.Replace("{TYPE}", "NetInfo (Roads)");
-            System.IO.StreamWriter file = new System.IO.StreamWriter("PrefabDumper\\" + "NetPrefabs.rst");
+            wikiPage = wikiPage.Replace("{TYPE}", "NetInfo");
+            file = new System.IO.StreamWriter("PrefabDumper\\" + "NetPrefabs.rst");
             file.WriteLine(wikiPage.Replace("{PREFABS}", prefabStr));
             file.Close();
-            
-            Utils.Log("Dumped " + count + " sprites to '" + spritePath + "'");
+
+            Utils.Log("Dumped " + count);
         }
 
     }

--- a/SpriteDumper/SpriteDumper.cs
+++ b/SpriteDumper/SpriteDumper.cs
@@ -23,6 +23,7 @@ namespace SpriteDumper {
             if (gameObj == null) {
                 gameObj = new GameObject("SpriteDumper");
                 gameObj.AddComponent<SpriteDumperObj>();
+                gameObj.AddComponent<PrefabDumperObj>();
             }
             Utils.Log("Loaded");
         }

--- a/SpriteDumper/SpriteDumper.csproj
+++ b/SpriteDumper/SpriteDumper.csproj
@@ -51,6 +51,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="PrefabDumperObj.cs" />
     <Compile Include="SpriteDumper.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="SpriteDumperObj.cs" />


### PR DESCRIPTION
Creates a C# file for easy accessing the names of buildings/vehicles/roads. For use when building roads/vehicles/buildings, and allows you to call one of:
``` C#
PrefabCollection<BuildingInfo>.FindLoaded(name);
PrefabCollection<VehicleInfo>.FindLoaded(name);
PrefabCollection<NetInfo>.FindLoaded(name);
```
These methods allow you to get the prefabricated objects (BuildingInfo, VehicleInfo, NetInfo), no matter which map you are on. Ex:
```
BuildingInfo myPoshMallInfo = PrefabCollection<BuildingInfo>.FindLoaded(PrefabNames.Buildings.PoshMall);
```